### PR TITLE
Config: Replace deprecated `default` config flag

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 optimizer = true
 optimizer_runs = 100000
 src = 'src'


### PR DESCRIPTION
On foundry's config file, `[default]` was deprecated for `[profile.default]`. Autofixed with `forge config --fix`.