### PR TITLE
Remove option to use modules without an upgradeable proxy

### DIFF
--- a/scripts/LocalDeploy.sol
+++ b/scripts/LocalDeploy.sol
@@ -18,8 +18,8 @@ contract LocalDeploy is Test {
             new GnosisSafeProxyFactory(),
             new UpgradeableModuleProxyFactory(),
             address(new GnosisSafe()),
-            address(new Roles(IAvatar(address(10)))),
-            address(new Budget(IAvatar(address(10)), IRoles(address(10))))
+            new Roles(),
+            new Budget()
         );
 
         vm.stopBroadcast();

--- a/scripts/TestinprodDeploy.sol
+++ b/scripts/TestinprodDeploy.sol
@@ -36,8 +36,8 @@ contract TestinprodDeploy is Test {
             GnosisSafeProxyFactory(safeProxyFactory),
             new UpgradeableModuleProxyFactory(),
             safeImpl,
-            address(new Roles(IAvatar(address(10)))),
-            address(new Budget(IAvatar(address(10)), IRoles(address(10))))
+            new Roles(),
+            new Budget()
         );
 
         vm.stopBroadcast();

--- a/src/bases/test/BasesTest.t.sol
+++ b/src/bases/test/BasesTest.t.sol
@@ -28,7 +28,7 @@ contract BasesTest is FirmTest {
         avatar = new AvatarStub();
         module = ModuleMock(
             factory.deployUpgradeableModule(
-                address(moduleOneImpl), abi.encodeCall(moduleOneImpl.initialize, (avatar, INITIAL_BAR)), 0
+                moduleOneImpl, abi.encodeCall(moduleOneImpl.initialize, (avatar, INITIAL_BAR)), 0
             )
         );
         vm.label(address(module), "Proxy");

--- a/src/budget/Budget.sol
+++ b/src/budget/Budget.sol
@@ -12,6 +12,7 @@ import {TimeShiftLib, EncodedTimeShift} from "./TimeShiftLib.sol";
 address constant NATIVE_ASSET = address(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
 uint256 constant NO_PARENT_ID = 0;
 uint64 constant INHERITED_RESET_TIME = 0;
+address constant IMPL_INIT_ADDRESS = address(1);
 
 /**
  * @title Budget
@@ -29,8 +30,9 @@ contract Budget is UpgradeableModule, ZodiacModule, RolesAuth {
     // INITIALIZATION
     ////////////////////////////////////////////////////////////////////////////////
 
-    constructor(IAvatar _safe, IRoles _roles) {
-        initialize(_safe, _roles);
+    constructor() {
+        // Initialize with impossible values in constructor so impl base cannot be used
+        initialize(IAvatar(IMPL_INIT_ADDRESS), IRoles(IMPL_INIT_ADDRESS));
     }
 
     function initialize(IAvatar _safe, IRoles _roles) public {

--- a/src/budget/test/Budget.t.sol
+++ b/src/budget/test/Budget.t.sol
@@ -20,10 +20,10 @@ contract BudgetTest is FirmTest {
     address RECEIVER = account("receiver");
     address SOMEONE_ELSE = account("someone else");
 
-    function setUp() public virtual {
+    function setUp() public {
         avatar = new AvatarStub();
         roles = new RolesStub();
-        budget = new Budget(avatar, roles);
+        budget = Budget(createProxy(new Budget(), abi.encodeCall(Budget.initialize, (avatar, roles))));
     }
 
     function testInitialState() public {
@@ -406,18 +406,5 @@ contract BudgetTest is FirmTest {
 
         assertEq(spent, initialSpent + amount);
         assertEq(nextResetTime, shift.isInherited() ? 0 : expectedNextResetTime);
-    }
-}
-
-contract BudgetWithProxyTest is BudgetTest {
-    UpgradeableModuleProxyFactory immutable factory = new UpgradeableModuleProxyFactory();
-    address immutable budgetImpl = address(new Budget(IAvatar(address(10)), IRoles(address(10))));
-
-    function setUp() public override {
-        avatar = new AvatarStub();
-        roles = new RolesStub();
-        budget =
-            Budget(factory.deployUpgradeableModule(budgetImpl, abi.encodeCall(Budget.initialize, (avatar, roles)), 0));
-        vm.label(address(roles), "BudgetProxy");
     }
 }

--- a/src/common/test/lib/FirmTest.sol
+++ b/src/common/test/lib/FirmTest.sol
@@ -3,9 +3,20 @@ pragma solidity 0.8.16;
 
 import "forge-std/Test.sol";
 
+import "../../../factory/UpgradeableModuleProxyFactory.sol";
+import {UpgradeableModule} from "../../../bases/UpgradeableModule.sol";
+
 contract FirmTest is Test {
+    UpgradeableModuleProxyFactory immutable proxyFactory = new UpgradeableModuleProxyFactory();
+
     function account(string memory _label) internal returns (address addr) {
         addr = vm.addr(uint256(keccak256(abi.encodePacked(_label))));
         vm.label(addr, _label);
+    }
+
+    // TODO: move to firm base or erc upgradeable
+    function createProxy(UpgradeableModule impl, bytes memory initdata) internal returns (address proxy) {
+        proxy = proxyFactory.deployUpgradeableModule(impl, initdata, 0);
+        vm.label(proxy, "Proxy");
     }
 }

--- a/src/factory/FirmFactory.sol
+++ b/src/factory/FirmFactory.sol
@@ -17,8 +17,8 @@ contract FirmFactory {
     UpgradeableModuleProxyFactory public immutable moduleFactory;
 
     address public immutable safeImpl;
-    address public immutable rolesImpl;
-    address public immutable budgetImpl;
+    Roles public immutable rolesImpl;
+    Budget public immutable budgetImpl;
 
     error EnableModuleFailed();
 
@@ -29,8 +29,8 @@ contract FirmFactory {
         GnosisSafeProxyFactory _safeFactory,
         UpgradeableModuleProxyFactory _moduleFactory,
         address _safeImpl,
-        address _rolesImpl,
-        address _budgetImpl
+        Roles _rolesImpl,
+        Budget _budgetImpl
     ) {
         safeFactory = _safeFactory;
         moduleFactory = _moduleFactory;

--- a/src/factory/TestinprodFactory.sol
+++ b/src/factory/TestinprodFactory.sol
@@ -8,8 +8,8 @@ contract TestinprodFactory is FirmFactory {
         GnosisSafeProxyFactory _safeFactory,
         UpgradeableModuleProxyFactory _moduleFactory,
         address _safeImpl,
-        address _rolesImpl,
-        address _budgetImpl
+        Roles _rolesImpl,
+        Budget _budgetImpl
     ) FirmFactory(_safeFactory, _moduleFactory, _safeImpl, _rolesImpl, _budgetImpl) {}
 
     function createFirmCopyingSafe(GnosisSafe baseSafe) external returns (GnosisSafe safe) {

--- a/src/factory/UpgradeableModuleProxyFactory.sol
+++ b/src/factory/UpgradeableModuleProxyFactory.sol
@@ -1,20 +1,25 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.16;
 
-import "zodiac/factory/ModuleProxyFactory.sol";
+import {UpgradeableModule} from "../bases/UpgradeableModule.sol";
 
-contract UpgradeableModuleProxyFactory is ModuleProxyFactory {
-    function createUpgradeableProxy(address _initialTarget, bytes32 _salt) internal returns (address addr) {
+contract UpgradeableModuleProxyFactory {
+    error TakenAddress(address proxy);
+    error FailedInitialization();
+
+    event ModuleProxyCreation(address indexed proxy, UpgradeableModule indexed implementation);
+
+    function createUpgradeableProxy(UpgradeableModule implementation, bytes32 salt) internal returns (address addr) {
         // if (address(target) == address(0)) revert ZeroAddress(target);
         // Removed as this is a responsibility of the caller and we shouldn't pay for the check on each proxy creation
         bytes memory initcode = abi.encodePacked(
             hex"73",
-            _initialTarget,
+            implementation,
             hex"7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc55603b8060403d393df3363d3d3760393d3d3d3d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af4913d913e3d9257fd5bf3"
         );
 
         assembly {
-            addr := create2(0, add(initcode, 0x20), mload(initcode), _salt)
+            addr := create2(0, add(initcode, 0x20), mload(initcode), salt)
         }
 
         if (addr == address(0)) {
@@ -22,17 +27,17 @@ contract UpgradeableModuleProxyFactory is ModuleProxyFactory {
         }
     }
 
-    function deployUpgradeableModule(address masterCopy, bytes memory initializer, uint256 saltNonce)
+    function deployUpgradeableModule(UpgradeableModule implementation, bytes memory initializer, uint256 salt)
         public
         returns (address proxy)
     {
-        proxy = createUpgradeableProxy(masterCopy, keccak256(abi.encodePacked(keccak256(initializer), saltNonce)));
+        proxy = createUpgradeableProxy(implementation, keccak256(abi.encodePacked(keccak256(initializer), salt)));
 
         (bool success,) = proxy.call(initializer);
         if (!success) {
             revert FailedInitialization();
         }
 
-        emit ModuleProxyCreation(proxy, masterCopy);
+        emit ModuleProxyCreation(proxy, implementation);
     }
 }

--- a/src/factory/test/mocks/UpgradeableModuleProxyFactoryMock.sol
+++ b/src/factory/test/mocks/UpgradeableModuleProxyFactoryMock.sol
@@ -5,6 +5,6 @@ import "../../UpgradeableModuleProxyFactory.sol";
 
 contract UpgradeableModuleProxyFactoryMock is UpgradeableModuleProxyFactory {
     function createUpgradeableProxy(address _target) public returns (address addr) {
-        return createUpgradeableProxy(_target, bytes32(0));
+        return createUpgradeableProxy(UpgradeableModule(_target), bytes32(0));
     }
 }

--- a/src/roles/Roles.sol
+++ b/src/roles/Roles.sol
@@ -6,6 +6,8 @@ import {UpgradeableModule} from "../bases/UpgradeableModule.sol";
 
 import {IRoles, ROOT_ROLE_ID, ROLE_MANAGER_ROLE, ONLY_ROOT_ROLE} from "./IRoles.sol";
 
+address constant IMPL_INIT_ADDRESS = address(1);
+
 /**
  * @title Roles
  * @author Firm (engineering@firm.org)
@@ -35,8 +37,8 @@ contract Roles is UpgradeableModule, IRoles {
     // INITIALIZATION
     ////////////////////////////////////////////////////////////////////////////////
 
-    constructor(IAvatar safe_) {
-        initialize(safe_);
+    constructor() {
+        initialize(IAvatar(IMPL_INIT_ADDRESS));
     }
 
     function initialize(IAvatar safe_) public {

--- a/src/roles/test/Roles.t.sol
+++ b/src/roles/test/Roles.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.16;
 
 import {FirmTest} from "../../common/test/lib/FirmTest.sol";
-import "../../factory/UpgradeableModuleProxyFactory.sol";
+
 
 import {SafeAware} from "../../bases/SafeAware.sol";
 import "../Roles.sol";
@@ -14,8 +14,8 @@ contract RolesTest is FirmTest {
     address SOMEONE = account("someone");
     address SOMEONE_ELSE = account("someone else");
 
-    function setUp() public virtual {
-        roles = new Roles(IAvatar(ADMIN));
+    function setUp() public {
+        roles = Roles(createProxy(new Roles(), abi.encodeCall(Roles.initialize, (IAvatar(ADMIN)))));
     }
 
     function testInitialRoot() public {
@@ -174,15 +174,5 @@ contract RolesTest is FirmTest {
         // However, when attempting to change the admin role, it will fail
         vm.expectRevert(abi.encodeWithSelector(Roles.UnauthorizedNotAdmin.selector, ROOT_ROLE_ID));
         roles.setRoleAdmin(ROOT_ROLE_ID, newRoleAdmin);
-    }
-}
-
-contract RolesWithProxyTest is RolesTest {
-    UpgradeableModuleProxyFactory immutable factory = new UpgradeableModuleProxyFactory();
-    address immutable rolesImpl = address(new Roles(IAvatar(address(1))));
-
-    function setUp() public override {
-        roles = Roles(factory.deployUpgradeableModule(rolesImpl, abi.encodeCall(Roles.initialize, (IAvatar(ADMIN))), 0));
-        vm.label(address(roles), "RolesProxy");
     }
 }


### PR DESCRIPTION
Several things in this PR:
- Remove option to use modules as non-proxies and autoinitialize implementations
- Remove option to use non-upgradeable proxies coming from Zodiac's factory
- Tighten types in proxy factory

close #68 